### PR TITLE
Add travel time ranges for two bars

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,20 +35,25 @@
 <div id="loading-bar-container">
     <div id="loading-bar">0%</div>
 </div>
+<div id="loading-bar-container-2">
+    <div id="loading-bar-2">0%</div>
+</div>
 
 <script>
     function updateLoadingBar() {
-        // First time range: 08:42 to 21:15
+        // First time range: yesterday 20:55 to today 13:20
         const startTime1 = new Date();
-        startTime1.setHours(12, 48 0, 0);
+        startTime1.setDate(startTime1.getDate() - 1);
+        startTime1.setHours(20, 55, 0, 0);
         const endTime1 = new Date();
-        endTime1.setHours(19, 08, 0, 0);
-        
-        // Second time range: 21:28 to 22:31
-       // const startTime2 = new Date();
-    //    startTime2.setHours(21, 28, 0, 0);
- //       const endTime2 = new Date();
-  //      endTime2.setHours(22, 31, 0, 0);
+        endTime1.setHours(13, 20, 0, 0);
+
+        // Second time range: yesterday 23:42 to today 09:26
+        const startTime2 = new Date();
+        startTime2.setDate(startTime2.getDate() - 1);
+        startTime2.setHours(23, 42, 0, 0);
+        const endTime2 = new Date();
+        endTime2.setHours(9, 26, 0, 0);
         
         // Current time
         const now = new Date();
@@ -64,14 +69,14 @@
         loadingBar1.innerText = Math.min(100, Math.max(0, percentageCompleted1.toFixed(2))) + '%';
         
         // Calculate total travel time and elapsed time for the second bar
-  //      const totalTravelTime2 = (endTime2 - startTime2) / 1000 / 60;
- //       const elapsedTime2 = (now - startTime2) / 1000 / 60;
-  //      const percentageCompleted2 = (elapsedTime2 / totalTravelTime2) * 100;
-        
+        const totalTravelTime2 = (endTime2 - startTime2) / 1000 / 60;
+        const elapsedTime2 = (now - startTime2) / 1000 / 60;
+        const percentageCompleted2 = (elapsedTime2 / totalTravelTime2) * 100;
+
         // Update the second loading bar
-//        const loadingBar2 = document.getElementById('loading-bar-2');
-//        loadingBar2.style.width = Math.min(100, Math.max(0, percentageCompleted2)) + '%'
-        //loadingBar2.innerText = Math.min(100, Math.max(0, percentageCompleted2.toFixed(2))) + '%';
+        const loadingBar2 = document.getElementById('loading-bar-2');
+        loadingBar2.style.width = Math.min(100, Math.max(0, percentageCompleted2)) + '%';
+        loadingBar2.innerText = Math.min(100, Math.max(0, percentageCompleted2.toFixed(2))) + '%';
     }
     
     updateLoadingBar();


### PR DESCRIPTION
## Summary
- add a second loading bar
- display travel time ranges from yesterday 20:55 to today 13:20 and from yesterday 23:42 to today 09:26

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686ca5865d7083288ad594572f8be5a9