### PR TITLE
Fix collapse when dragging bars

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,6 +267,11 @@
             }
         });
         function startDrag(e) {
+            const rect = wrapper.getBoundingClientRect();
+            wrapper.style.width  = rect.width + 'px';
+            wrapper.style.height = rect.height + 'px';
+            wrapper.style.left   = rect.left + 'px';
+            wrapper.style.top    = rect.top + 'px';
             wrapper.classList.add('dragging');
             document.body.appendChild(wrapper);
             moveDrag(e);
@@ -300,12 +305,18 @@
                 if (b) bars.push(b);
             });
             saveBars();
-            wrapper.style.left = wrapper.style.top = '';
+            wrapper.style.width =
+            wrapper.style.height =
+            wrapper.style.left =
+            wrapper.style.top = '';
         }
         function cancelDrag() {
             wrapper.classList.remove('dragging');
             barsContainer.appendChild(wrapper);
-            wrapper.style.left = wrapper.style.top = '';
+            wrapper.style.width =
+            wrapper.style.height =
+            wrapper.style.left =
+            wrapper.style.top = '';
         }
         edit.addEventListener('click', () => {
             editingBar = barObj;


### PR DESCRIPTION
## Summary
- keep dragged bar's dimensions and position when moving it to the body
- clear inline styles when dropping or canceling drag

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6875076142bc8328b9695b1d8e3ee1f4